### PR TITLE
added boardId update to issue on patch with projectId

### DIFF
--- a/app/api/issues/[id]/route.ts
+++ b/app/api/issues/[id]/route.ts
@@ -43,7 +43,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
   if (status !== undefined) updateData.status = status;
   if (priority !== undefined) updateData.priority = priority;
   if (assignedToUserId !== undefined) updateData.assignedToUserId = assignedToUserId;
-  if (projectId !== undefined) updateData.projectId = projectId;
+  if (projectId !== undefined) updateData.projectId = projectId, updateData.boardId = projectId;
   if (position !== undefined) updateData.position = position;
 
   const updateIssue = await prisma.issue.update({


### PR DESCRIPTION
Found a bug when adding issues to project, only the projectId gets updated, not the boardId, so the issue will not show up on board.
I added update to boardId when projectId gets updated with the same value that got sent to api as the projectId since they should be the same.